### PR TITLE
Fix import and print statement for python3 compatibility

### DIFF
--- a/src/occupancy_grid_python/__init__.py
+++ b/src/occupancy_grid_python/__init__.py
@@ -1,1 +1,1 @@
-from occupancy_grid_impl import OccupancyGridManager
+from .occupancy_grid_impl import OccupancyGridManager

--- a/src/occupancy_grid_python/occupancy_grid_impl.py
+++ b/src/occupancy_grid_python/occupancy_grid_impl.py
@@ -285,4 +285,4 @@ if __name__ == '__main__':
         for j in l:
             accum += str(ogm.get_cost_from_costmap_x_y(i, j)) + ' '
             # print(ogm.get_cost_from_costmap_x_y(i, 270))
-        print accum
+        print(accum)


### PR DESCRIPTION
Fixes the import of `occupancy_grid_impl` for Python 3 in ROS Noetic. Also fixes a Python-2-style print statement.